### PR TITLE
Power addition during charging

### DIFF
--- a/RCAIDE/Library/Methods/Thermal_Management/Batteries/Liquid_Cooled_Wavy_Channel/wavy_channel_rating_model.py
+++ b/RCAIDE/Library/Methods/Thermal_Management/Batteries/Liquid_Cooled_Wavy_Channel/wavy_channel_rating_model.py
@@ -185,7 +185,8 @@ def  wavy_channel_rating_model(HAS,battery,bus,coolant_line,Q_heat_gen,T_cell,st
     state.conditions.energy[coolant_line.tag][HAS.tag].effectiveness[t_idx+1]              = heat_transfer_efficiency
     state.conditions.energy[coolant_line.tag][HAS.tag].power[t_idx+1]                      = Power
     
-    state.conditions.energy[bus.tag].power_draw[t_idx+1]                                  += Power 
+    if not state.conditions.energy.recharging:
+        state.conditions.energy[bus.tag].power_draw[t_idx+1]                                  += Power 
 
     # To be introduced when turndown ratio is a thing in the future. 
     #if turndown_ratio == 0:

--- a/RCAIDE/Library/Methods/Thermal_Management/Heat_Exchangers/Cross_Flow_Heat_Exchanger/cross_flow_hex_rating_model.py
+++ b/RCAIDE/Library/Methods/Thermal_Management/Heat_Exchangers/Cross_Flow_Heat_Exchanger/cross_flow_hex_rating_model.py
@@ -305,7 +305,8 @@ def cross_flow_hex_rating_model(HEX,state,bus,coolant_line, delta_t,t_idx):
     state.conditions.energy[coolant_line.tag][HEX.tag].air_mass_flow_rate[t_idx+1]         = m_dot_c  
     state.conditions.energy[coolant_line.tag][HEX.tag].air_inlet_pressure[t_idx+1]         = P_i_c 
     state.conditions.energy[coolant_line.tag][HEX.tag].coolant_inlet_pressure[t_idx+1]     = P_i_h
-    state.conditions.energy[coolant_line.tag][HEX.tag].effectiveness_HEX[t_idx+1]          = eff_hex   
-    state.conditions.energy[bus.tag].power_draw[t_idx+1]                                  += P_hex 
+    state.conditions.energy[coolant_line.tag][HEX.tag].effectiveness_HEX[t_idx+1]          = eff_hex  
+    if not state.conditions.energy.recharging: 
+        state.conditions.energy[bus.tag].power_draw[t_idx+1]                                  += P_hex 
     
     return  


### PR DESCRIPTION
The TMS was drawing power from the bus in the recharge segment. This is set to zero as it is assumed that it draws power from ground. 